### PR TITLE
Update link to MPTM extensions

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -1619,7 +1619,7 @@ Support for these chunks was added in MO3 2.4.1, released in January 2016.</p>
           OpenMPT Instrument Extensions</a>. Same format as in OpenMPT-made files.
      <li> <code>STPM</code>: <a href="https://wiki.openmpt.org/Development:_OpenMPT_Format_Extensions#OpenMPT_Song_Extensions">
           OpenMPT Song Extensions</a>. Same format as in OpenMPT-made files.
-     <li> <code>228</code>: <a href="https://wiki.openmpt.org/Development:_OpenMPT_Format_Extensions#228_extensions">
+     <li> <code>228</code>: <a href="https://wiki.openmpt.org/Development:_228_Extensions">
           OpenMPT MPTM extensions</a>. Same format as in
           OpenMPT-made files. These only follow if the original file was an MPTM
           file.


### PR DESCRIPTION
`https://wiki.openmpt.org/Development:_OpenMPT_Format_Extensions#228_extensions` -> `https://wiki.openmpt.org/Development:_228_Extensions`